### PR TITLE
Baseline assess visibility of sites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,8 @@ _targets/
 
 # Workflow-specific filepaths
 4_compile_sites/in/*
+6_siteSR_stack/mid/*
+6_siteSR_stack/down/*
+
+# Python environment
+env/*

--- a/5_site_visibility.R
+++ b/5_site_visibility.R
@@ -1,0 +1,66 @@
+# Targets list to assess site remote sensing visibility
+
+# Source the functions that will be used to build the targets in p3_targets_list
+tar_source(files = "5_site_visibility/src/")
+
+p5_site_visibility <- list(
+  # make directories if needed
+  tar_target(
+    name = p5_check_dir_structure,
+    command = {
+      directories = c("5_site_visibility/out/")
+      
+      walk(directories, function(dir) {
+        if(!dir.exists(dir)){
+          dir.create(dir)
+        }
+      })
+    },
+    cue = tar_cue("always"),
+    priority = 1
+  ),
+  
+  # Create the unique HUCs to map over
+  tar_target(
+    name = p5_wbd_HUC4_list,
+    command ={ 
+      filtered_sites <- p4_add_NHD_waterbody_info %>% 
+        # if there isn't a nhd waterbody to relate to, drop it from this summary
+        filter(!is.na(nhd_permanent_identifier)) 
+      HUC8s <- unique(na.omit(filtered_sites$HUCEightDigitCode))
+      HUC8s %>% 
+        str_sub(., 1, 4) %>% 
+        unique(.)
+    }
+  ),
+  
+  # initial assessment of satellite visibility is completed by measuring distance
+  # to shore. We know that this can be an overestimate in waterbodies with varying
+  # surface level, but it is a good starting point to limit the queries sent to
+  # GEE
+  tar_target(
+    name = p5_sites_with_distance_to_shore,
+    command = calculate_distance_to_shore(sites_with_waterbodies = p4_add_NHD_waterbody_info, 
+                                          huc4 = p5_wbd_HUC4_list),
+    pattern = p5_wbd_HUC4_list,
+    packages = c("tidyverse", "sf", "arcgis")
+  ),
+  
+  # to mimic decisions in riverSR, we'll use a cutoff of 30m here
+  tar_target(
+    name = p5_visible_sites,
+    command = {
+      visible_sites <- p5_sites_with_distance_to_shore %>% 
+        # coerce unit object to numeric for filtering and writing the csv
+        mutate(dist_to_shore = as.numeric(dist_to_shore)) %>% 
+        filter(dist_to_shore >= 30) %>% 
+        st_drop_geometry() %>% 
+        rowid_to_column()
+      # save the file and return the dataframe
+      write_csv(visible_sites, "5_site_visibility/out/visible_sites.csv")
+      visible_sites
+    },
+    packages = c("sf", "grid", "tidyverse")
+  )
+  
+)

--- a/5_site_visibility.R
+++ b/5_site_visibility.R
@@ -46,7 +46,7 @@ p5_site_visibility <- list(
     packages = c("tidyverse", "sf", "arcgis")
   ),
   
-  # to mimic decisions in riverSR, we'll use a cutoff of 30m here
+  # to mimic decisions in riverSR, we'll use a cutoff of 30m from a waterbody edge.
   tar_target(
     name = p5_visible_sites,
     command = {
@@ -63,4 +63,5 @@ p5_site_visibility <- list(
     packages = c("sf", "grid", "tidyverse")
   )
   
+  # deal with rivers! filter by distance to flowline (30m too)
 )

--- a/5_site_visibility/src/calculate_distance_to_shore.R
+++ b/5_site_visibility/src/calculate_distance_to_shore.R
@@ -1,0 +1,46 @@
+#' @title Calculate a point's distance to shore
+#' 
+#' @description
+#' Given points that have assigned NHD waterbodies, calculate the distance of the
+#' point to the shoreline
+#' 
+calculate_distance_to_shore <- function(sites_with_waterbodies, huc4) {
+  # filter the waterbodies to those within the huc
+  sf_subset <- sites_with_waterbodies %>% 
+    filter(str_sub(HUCEightDigitCode, 1, 4) == huc4) %>% 
+    filter(!is.na(nhd_permanent_identifier))
+  
+  # set up MapSever
+  # point to the nhdplushr MapServer url
+  nhd_plus_hr_url <- "https://hydro.nationalmap.gov/arcgis/rest/services/NHDPlus_HR/MapServer"
+  # open that connection
+  nhd_hr <- arc_open(nhd_plus_hr_url)
+  # grab the NHD waterbodies layer using the mapserver and SQL query for the NHD Permanent IDs
+  waterbodies <- get_layer(nhd_hr, 9)
+  query = paste0("Permanent_Identifier IN (",
+                 paste(
+                   paste0("'",
+                          unique(sf_subset$nhd_permanent_identifier),
+                          "'"),
+                   collapse = (", ")),
+                 ")")
+  
+  # filter the waterbodies by permanent identifier list
+  filtered_waterbodies <- arc_select(waterbodies,
+                                     # use SQL query for where
+                                     where = query)
+  
+  # create an sf from the points
+  points = st_as_sf(sf_subset, coords = c("WGS84_Longitude", "WGS84_Latitude"), crs = "EPSG:4326")
+  
+  # cast the waterbodies into a linestrings to measure distance
+  waterbody_boundary <- st_cast(st_geometry(filtered_waterbodies), "MULTILINESTRING") %>% 
+    # dissolve these into a single geometry, since the identity of the line doesn't
+    # matter
+    st_union()
+  # transform the point into same crs
+  points = st_transform(points, crs = st_crs(waterbody_boundary))
+  # measure the distance, rounded to integer
+  sf_subset$dist_to_shore <- round(st_distance(points, waterbody_boundary), 0)
+  sf_subset
+}

--- a/5_site_visibility/src/calculate_distance_to_shore.R
+++ b/5_site_visibility/src/calculate_distance_to_shore.R
@@ -4,6 +4,12 @@
 #' Given points that have assigned NHD waterbodies, calculate the distance of the
 #' point to the shoreline
 #' 
+#' @param sites_with_waterbodies dataframe object of sites with waterbodies assigned
+#' to calculate distance from shore
+#' @param huc4 4-digit character string to filter sites by
+#' 
+#' @returns description
+#' 
 calculate_distance_to_shore <- function(sites_with_waterbodies, huc4) {
   # filter the waterbodies to those within the huc
   sf_subset <- sites_with_waterbodies %>% 

--- a/_targets.R
+++ b/_targets.R
@@ -15,8 +15,7 @@ tar_option_set(
 tar_source(files = c(
   "src/",
   "4_compile_sites.R",
-  "5_site_visibility.R",
-  "6_siteSR_stack.R"))
+  "5_site_visibility.R"))
 
 # The list of targets/steps
 config_targets <- list(

--- a/_targets.R
+++ b/_targets.R
@@ -14,7 +14,9 @@ tar_option_set(
 # Run the R scripts with custom functions:
 tar_source(files = c(
   "src/",
-  "4_compile_sites.R"))
+  "4_compile_sites.R",
+  "5_site_visibility.R",
+  "6_siteSR_stack.R"))
 
 # The list of targets/steps
 config_targets <- list(
@@ -194,4 +196,5 @@ config_targets <- list(
 
 # Full targets list
 c(config_targets,
-  p4_compile_sites)
+  p4_compile_sites,
+  p5_site_visibility)


### PR DESCRIPTION
Hey MB!

Another stair-step of a PR in creating some architecture for siteSR. This is the initial architecture for determining whether or not a site is RS-visible, where the threshold is that the site must be >= 30m from a shoreline to be considered RS-visible This is also some MVP code...

Known issues:
1) #21 this currently excludes rivers (which would be associated with flowlines, not waterbodies), I need a quick matchup dataset for another project, so really just laying down some basic code
2) This is intentionally only run for sites that fall within waterbodies within HUCs that we've been able to track down to reduce run time and headaches. When #17 is fixed, we can re-pull.

Please review (by Friday?) for general style guide/functionality/efficiency. 

Thank you!
