### PR TITLE
siteSR locations file patch for unclosed quote

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # AquaMatch_siteSR
 
-The third repository in the AquaMatch constellation. This repository determines remote sensing visibility and acquires surface reflectance data for RS-visible sites from the Water Quality Portal harmonized datasets.
+The third repository in the AquaMatch constellation. This repository determines remote sensing visibility and acquires surface reflectance data for RS-visible sites from the Water Quality Portal harmonized datasets and National Water Information System site locations.
 
 We suggest users use the `run_targets.Rmd` script to run this workflow, as it walks through all necessary configuration and authentication steps prior to running the workflow.
 
 This repository is covered by the MIT use license. We request that all downstream uses of this work be available to the public when possible.
+
+NOTE: there is a patch (`a_all_site_locations_patch.Rmd`) to remove an unclosed quote from the `siteSR_collated_WQP_NWIS_sites_with_NHD_info_2025-06-04.csv` file for publication at EDI. This creates a file with the name `siteSR_collated_WQP_NWIS_sites_with_NHD_info_2026-01-18.csv` these files are identical other than the deletion of the single instance of the unclosed quote in the file dated 2025-06-04. End users can use either file for downstream applications.
 
 ## Prerequisites
 

--- a/a_all_site_locations_patch.Rmd
+++ b/a_all_site_locations_patch.Rmd
@@ -1,0 +1,40 @@
+---
+title: "a_all_site_locations_patch"
+output: html_document
+---
+
+This file provides a quick patch for a single unclosed quote in the loc_id 
+column of the collated site list for siteSR 
+(siteSR_collated_WQP_NWIS_sites_with_NHD_info_2025-06-04.csv). We would normally 
+fix this in the code proper, but that would require a re-run of the pipeline because
+without the quote, this line is a duplicate of another, which would cause
+the pipeline to be re-run because the upstream target will have changed. For the 
+purposes of satisfying EDI requirements for which there can not be an unclosed 
+quote in column data, we will run this patch. This change should not affect any
+user's ability to use either the 2025-06-04 version or the 2026-01-28 version
+of the siteSR file. The associated {targets} remain unchanged and users may 
+encounter this issue if publishing on EDI until this is fixed in the pipeline.
+See [Issue #45](https://github.com/AquaSat/AquaMatch_siteSR/issues/45) for details.
+
+```{r}
+library(tidyverse)
+
+sites <- read_csv("a_compile_sites/out/siteSR_collated_WQP_NWIS_sites_with_NHD_info_2025-06-04.csv")
+
+# find rows with an odd number of double quotes
+odd_quote <- sites[str_count(sites$loc_id, '"') %% 2 != 0, ]
+
+# phew, there's only one. 
+sites <- sites %>%
+  mutate(loc_id = if_else(str_count(loc_id, '"') %% 2 != 0, 
+                          str_remove_all(loc_id, '"'), 
+                          loc_id))
+
+# make sure it's gone
+odd_quote <- sites[str_count(sites$loc_id, '"') %% 2 != 0, ]
+# and make sure it didn't change other instances with a quote
+other_quotes <- sites[grepl('"', sites$loc_id),]
+
+write_csv(sites, "a_compile_sites/out/siteSR_collated_WQP_NWIS_sites_with_NHD_info_2026-01-28.csv")
+```
+


### PR DESCRIPTION
Hey Michael, 

This is the quick patch for the unclosed quote. I also made an issue for this (#45) in case someone in the future updates the pipeline and/or re-runs to update the dataset. Can you re-read and make sure the issue and the context provided in this Rmd are logical? I decided we didn't need to go through the frustration of updating any of the Drive id's here out of fear it would trigger a re-run of the pipeline since it's not anything that would actually impact a user from being able to use the file **with** the unclosed quote.